### PR TITLE
Streamline homepage

### DIFF
--- a/ibli/modules/custom/ibli_general/ibli_general.pages_default.inc
+++ b/ibli/modules/custom/ibli_general/ibli_general.pages_default.inc
@@ -16,7 +16,10 @@ function ibli_general_default_page_manager_pages() {
   $page->admin_title = 'Contact Us';
   $page->admin_description = 'Contact Us panel';
   $page->path = 'contact-us';
-  $page->access = array();
+  $page->access = array(
+    'type' => 'none',
+    'settings' => NULL,
+  );
   $page->menu = array();
   $page->arguments = array();
   $page->conf = array(

--- a/ibli/modules/custom/ibli_homepage/ibli_homepage.pages_default.inc
+++ b/ibli/modules/custom/ibli_homepage/ibli_homepage.pages_default.inc
@@ -121,30 +121,8 @@ function ibli_homepage_default_page_manager_pages() {
     $pane->uuid = '78c41d5e-4ebb-4277-97b8-38fefdf6a38c';
     $display->content['new-78c41d5e-4ebb-4277-97b8-38fefdf6a38c'] = $pane;
     $display->panels['right'][0] = 'new-78c41d5e-4ebb-4277-97b8-38fefdf6a38c';
-    $pane = new stdClass();
-    $pane->pid = 'new-48692876-9cb0-4c7f-be3c-c2cc498acb46';
-    $pane->panel = 'top';
-    $pane->type = 'boxes_below_map';
-    $pane->subtype = 'boxes_below_map';
-    $pane->shown = TRUE;
-    $pane->access = array();
-    $pane->configuration = array(
-      'override_title' => 0,
-      'override_title_text' => '',
-    );
-    $pane->cache = array();
-    $pane->style = array(
-      'settings' => NULL,
-    );
-    $pane->css = array();
-    $pane->extras = array();
-    $pane->position = 0;
-    $pane->locks = array();
-    $pane->uuid = '48692876-9cb0-4c7f-be3c-c2cc498acb46';
-    $display->content['new-48692876-9cb0-4c7f-be3c-c2cc498acb46'] = $pane;
-    $display->panels['top'][0] = 'new-48692876-9cb0-4c7f-be3c-c2cc498acb46';
   $display->hide_title = PANELS_TITLE_FIXED;
-  $display->title_pane = 'new-48692876-9cb0-4c7f-be3c-c2cc498acb46';
+  $display->title_pane = '0';
   $handler->conf['display'] = $display;
   $page->default_handlers[$handler->name] = $handler;
   $pages['homepage'] = $page;

--- a/ibli/modules/custom/ibli_homepage/plugins/content_types/last_updates/last-updates.tpl.php
+++ b/ibli/modules/custom/ibli_homepage/plugins/content_types/last_updates/last-updates.tpl.php
@@ -4,12 +4,12 @@
   </h2>
 </div>
 <ul class="nav nav-tabs">
-  <li class="active"><a href="#partners" data-toggle="tab"><?php print t('Partners'); ?></a></li>
+  <li class="active"><a href="#news" data-toggle="tab"><?php print t('News'); ?></a></li>
   <li><a href="#events" data-toggle="tab"><?php print t('Events'); ?></a></li>
-  <li><a href="#news" data-toggle="tab"><?php print t('News'); ?></a></li>
+  <li><a href="#partners" data-toggle="tab"><?php print t('Partners'); ?></a></li>
 </ul>
 <div class="tab-content">
-  <div class="tab-pane active" id="partners">
+  <div class="tab-pane" id="partners">
     <div class="media">
       <a class="pull-left" href="#">
         <img class="media-object" src="<?php print variable_get('ibli_images_path'); ?>/eu.png" alt="Blog Message" />
@@ -39,7 +39,7 @@
   <div class="tab-pane" id="events">
     <iframe src="https://www.google.com/calendar/embed?showTitle=0&amp;showNav=0&amp;showDate=0&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;mode=AGENDA&amp;height=300&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;ctz=Africa%2FNairobi" style=" border-width:0 " width="360" height="300" frameborder="0" scrolling="no"></iframe>
   </div>
-  <div class="tab-pane" id="news">
+  <div class="tab-pane  active" id="news">
     <div class="media">
       <a class="pull-left" href="#">
         <img class="media-object" src="<?php print variable_get('ibli_images_path'); ?>/face1.jpg" alt="Blog Message" />


### PR DESCRIPTION
#153 Remove boxes below map and switch "news" and "partners" tabs in homepage.

![selection_004](https://cloud.githubusercontent.com/assets/2690042/3737199/ac7b61f4-1734-11e4-97bf-bcf52731f706.png)

@niryariv Notice that the box is gone only in the homepage, and still stored as a plugin under ibli_homepage module.
